### PR TITLE
Use curl instead of wget on RHEL/CentOS

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ sudo apt install ./dive_0.3.0_linux_amd64.deb
 
 **RHEL/Centos**
 ```bash
-wget https://github.com/wagoodman/dive/releases/download/v0.3.0/dive_0.3.0_linux_amd64.rpm
+curl -OL https://github.com/wagoodman/dive/releases/download/v0.3.0/dive_0.3.0_linux_amd64.rpm
 rpm -i dive_0.3.0_linux_amd64.rpm
 ```
 


### PR DESCRIPTION
Although `wget` is commonly installed on RHEL/CentOS, they don't include it by default in the more minimal installation selections (eg "Basic server" type of thing).

`curl` is part of all RHEL/CentOS installations though, so this PR adjusts the dive installation command to use that instead. :smile: